### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # 30-Days-of-Code
 Solutions to tasks from 30daysofcode.xyz
+
+[![Run on Repl.it](https://repl.it/badge/github/Joggyjagz7/30-Days-of-Code)](https://repl.it/github/Joggyjagz7/30-Days-of-Code)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).